### PR TITLE
最近追加された商品をDBから取得する時の上限を修正。

### DIFF
--- a/src/main/resources/com/rakucari/aki/selectlatestgoods/mapper/LatestGoodsMapper.xml
+++ b/src/main/resources/com/rakucari/aki/selectlatestgoods/mapper/LatestGoodsMapper.xml
@@ -48,7 +48,7 @@
             gi.del_flg = false
         ORDER BY
             g.added_time DESC
-        LIMIT 2;
+        LIMIT 4;
     </select>
 
     <resultMap id="GoodsMap" type="com.rakucari.aki.goods.Goods">


### PR DESCRIPTION
# 変更点
- 最近追加された商品をDBから取得する件数の上限を2から4に変更。