### PR TITLE
商品出品ページのセレクトボックスの値を取得するAPIを実装。

### DIFF
--- a/src/main/java/com/rakucari/aki/category/MajorCategory.java
+++ b/src/main/java/com/rakucari/aki/category/MajorCategory.java
@@ -8,6 +8,8 @@ import java.util.List;
  *
  */
 public class MajorCategory {
+    private String id;
+
     private String name;
 
     /** カテゴリーから検索するページのURL。*/
@@ -15,6 +17,14 @@ public class MajorCategory {
 
     /** このカテゴリーに属するサブカテゴリー。*/
     private List<SubCategory> subCategories;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
 
     public String getName() {
         return name;

--- a/src/main/java/com/rakucari/aki/selectgoodsoptions/FeeResponsibility.java
+++ b/src/main/java/com/rakucari/aki/selectgoodsoptions/FeeResponsibility.java
@@ -1,0 +1,29 @@
+package com.rakucari.aki.selectgoodsoptions;
+
+/**
+ * 配送料負担を扱うデータクラス。
+ * @author Akihiro Yamada
+ *
+ */
+public class FeeResponsibility {
+    private String id;
+
+    private String feeResponsibility;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getFeeResponsibility() {
+        return feeResponsibility;
+    }
+
+    public void setFeeResponsibility(String feeResponsibility) {
+        this.feeResponsibility = feeResponsibility;
+    }
+
+}

--- a/src/main/java/com/rakucari/aki/selectgoodsoptions/GoodsOptions.java
+++ b/src/main/java/com/rakucari/aki/selectgoodsoptions/GoodsOptions.java
@@ -1,0 +1,68 @@
+package com.rakucari.aki.selectgoodsoptions;
+
+import java.util.List;
+
+import com.rakucari.aki.category.MajorCategory;
+
+/**
+ * 商品出品ページに表示するセレクトボックスのデータ。
+ * @author Akihiro Yamada
+ *
+ */
+public class GoodsOptions {
+
+    private List<MajorCategory> category;
+
+    /** 商品の状態。 */
+    private List<UseStatus> useStatus;
+
+    /** 配送料負担。 */
+    private List<FeeResponsibility> feeResponsibility;
+
+    private List<SrcRegion> srcRegion;
+
+    private List<ShippingDate> shippingDate;
+
+    public List<MajorCategory> getCategory() {
+        return category;
+    }
+
+    public void setCategory(List<MajorCategory> category) {
+        this.category = category;
+    }
+
+    public List<UseStatus> getUseStatus() {
+        return useStatus;
+    }
+
+    public void setUseStatus(List<UseStatus> useStatus) {
+        this.useStatus = useStatus;
+    }
+
+    public List<FeeResponsibility> getFeeResponsibility() {
+        return feeResponsibility;
+    }
+
+    public void setFeeResponsibility(
+            List<FeeResponsibility> feeResponsibility) {
+        this.feeResponsibility = feeResponsibility;
+    }
+
+    public List<SrcRegion> getSrcRegion() {
+        return srcRegion;
+    }
+
+    public void setSrcRegion(List<SrcRegion> srcRegion) {
+        this.srcRegion = srcRegion;
+    }
+
+    public List<ShippingDate> getShippingDate() {
+        return shippingDate;
+    }
+
+    public void setShippingDate(List<ShippingDate> shippingDate) {
+        this.shippingDate = shippingDate;
+    }
+
+
+}

--- a/src/main/java/com/rakucari/aki/selectgoodsoptions/GoodsOptionsController.java
+++ b/src/main/java/com/rakucari/aki/selectgoodsoptions/GoodsOptionsController.java
@@ -1,0 +1,31 @@
+package com.rakucari.aki.selectgoodsoptions;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 商品出品ページに表示するセレクトボックスのデータを取得するコントローラークラス。
+ * @author Akihiro Yamada
+ *
+ */
+
+@RequestMapping("goods-options")
+@RestController
+@CrossOrigin
+@Scope("prototype")
+public class GoodsOptionsController {
+
+    @Autowired
+    GoodsOptionsService goodsOptionsService;
+
+    @RequestMapping(method = RequestMethod.GET)
+    public GoodsOptions fetchGoodsOptions() {
+
+        return goodsOptionsService.fetchGoodsOptions();
+    }
+
+}

--- a/src/main/java/com/rakucari/aki/selectgoodsoptions/GoodsOptionsService.java
+++ b/src/main/java/com/rakucari/aki/selectgoodsoptions/GoodsOptionsService.java
@@ -1,0 +1,33 @@
+package com.rakucari.aki.selectgoodsoptions;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.rakucari.aki.selectgoodsoptions.mapper.GoodsOptionsMapper;
+
+/**
+ * 商品出品ページに表示するセレクトボックスのデータを取得するサービスクラス。
+ * @author Akihiro Yamada
+ *
+ */
+@Service
+@Transactional
+public class GoodsOptionsService {
+
+    @Autowired
+    GoodsOptionsMapper goodsOptionsMapper;
+
+    public GoodsOptions fetchGoodsOptions() {
+        GoodsOptions goodsOptions = new GoodsOptions();
+
+        goodsOptions.setCategory(goodsOptionsMapper.findAllCategory());
+        goodsOptions.setUseStatus(goodsOptionsMapper.findAllUseStatus());
+        goodsOptions.setFeeResponsibility(
+                goodsOptionsMapper.findAllFeeResponsibility());
+        goodsOptions.setSrcRegion(goodsOptionsMapper.findAllSrcRegion());
+        goodsOptions.setShippingDate(goodsOptionsMapper.findAllShippingDate());
+
+        return goodsOptions;
+    }
+}

--- a/src/main/java/com/rakucari/aki/selectgoodsoptions/ShippingDate.java
+++ b/src/main/java/com/rakucari/aki/selectgoodsoptions/ShippingDate.java
@@ -1,0 +1,29 @@
+package com.rakucari.aki.selectgoodsoptions;
+
+/**
+ * 配送予定日を扱うデータクラス。
+ * @author Akihiro Yamada
+ *
+ */
+public class ShippingDate {
+    private String id;
+
+    private String shippingDate;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getShippingDate() {
+        return shippingDate;
+    }
+
+    public void setShippingDate(String shippingDate) {
+        this.shippingDate = shippingDate;
+    }
+
+}

--- a/src/main/java/com/rakucari/aki/selectgoodsoptions/SrcRegion.java
+++ b/src/main/java/com/rakucari/aki/selectgoodsoptions/SrcRegion.java
@@ -1,0 +1,29 @@
+package com.rakucari.aki.selectgoodsoptions;
+
+/**
+ * 発送元地域を扱うデータクラス。
+ * @author Akihiro Yamada
+ *
+ */
+public class SrcRegion {
+    private String id;
+
+    private String srcRegion;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getSrcRegion() {
+        return srcRegion;
+    }
+
+    public void setSrcRegion(String srcRegion) {
+        this.srcRegion = srcRegion;
+    }
+
+}

--- a/src/main/java/com/rakucari/aki/selectgoodsoptions/UseStatus.java
+++ b/src/main/java/com/rakucari/aki/selectgoodsoptions/UseStatus.java
@@ -1,0 +1,30 @@
+package com.rakucari.aki.selectgoodsoptions;
+
+/**
+ * 商品状態を扱うデータクラス。
+ * @author Akihiro Yamada
+ *
+ */
+public class UseStatus {
+
+    private String id;
+
+    private String useStatus;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUseStatus() {
+        return useStatus;
+    }
+
+    public void setUseStatus(String useStatus) {
+        this.useStatus = useStatus;
+    }
+
+}

--- a/src/main/java/com/rakucari/aki/selectgoodsoptions/mapper/GoodsOptionsMapper.java
+++ b/src/main/java/com/rakucari/aki/selectgoodsoptions/mapper/GoodsOptionsMapper.java
@@ -1,0 +1,50 @@
+package com.rakucari.aki.selectgoodsoptions.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.rakucari.aki.category.MajorCategory;
+import com.rakucari.aki.selectgoodsoptions.FeeResponsibility;
+import com.rakucari.aki.selectgoodsoptions.ShippingDate;
+import com.rakucari.aki.selectgoodsoptions.SrcRegion;
+import com.rakucari.aki.selectgoodsoptions.UseStatus;
+
+/**
+ * 商品出品ページに表示するセレクトボックスのデータに関するデータアクセス機能を提供。
+ * @author Akihiro Yamada
+ *
+ */
+@Mapper
+public interface GoodsOptionsMapper {
+
+    /**
+     * 全カテゴリーデータを取得。
+     * @return 全カテゴリーデータ。
+     */
+    public List<MajorCategory> findAllCategory();
+
+    /**
+     * 全商品状態を取得。
+     * @return 全商品状態。
+     */
+    public List<UseStatus> findAllUseStatus();
+
+    /**
+     * 全配送料負担を取得。
+     * @return 全配送料負担。
+     */
+    public List<FeeResponsibility> findAllFeeResponsibility();
+
+    /**
+     * 全発送元地域を取得。
+     * @return
+     */
+    public List<SrcRegion> findAllSrcRegion();
+
+    /**
+     * 全出荷予定日を取得。
+     * @return 全出荷予定日。
+     */
+    public List<ShippingDate> findAllShippingDate();
+}

--- a/src/main/resources/com/rakucari/aki/selectgoodsoptions/mapper/GoodsOptionsMapper.xml
+++ b/src/main/resources/com/rakucari/aki/selectgoodsoptions/mapper/GoodsOptionsMapper.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.rakucari.aki.selectgoodsoptions.mapper.GoodsOptionsMapper">
+    <select id="findAllCategory" resultType="com.rakucari.aki.category.MajorCategory">
+        SELECT
+            id,
+            name
+        FROM
+            category
+        WHERE
+            del_flg = false
+    </select>
+
+    <select id="findAllUseStatus" resultType="com.rakucari.aki.selectgoodsoptions.UseStatus">
+        SELECT
+            id,
+            use_status AS useStatus
+        FROM
+            use_status
+        WHERE
+            del_flg = false
+    </select>
+
+    <select id="findAllFeeResponsibility" resultType="com.rakucari.aki.selectgoodsoptions.FeeResponsibility">
+        SELECT
+            id,
+            fee_responsibility AS feeResponsibility
+        FROM
+            fee_responsibility
+        WHERE
+            del_flg = false
+    </select>
+
+    <select id="findAllSrcRegion" resultType="com.rakucari.aki.selectgoodsoptions.SrcRegion">
+        SELECT
+            id,
+            prefecture_name AS srcRegion
+        FROM
+            prefecture
+    </select>
+
+    <select id="findAllShippingDate" resultType="com.rakucari.aki.selectgoodsoptions.ShippingDate">
+        SELECT
+            id,
+            shipping_date AS shippingDate
+        FROM
+            shipping_date
+        WHERE
+            del_flg = false
+    </select>
+
+</mapper>

--- a/src/main/resources/spring/application-config.xml
+++ b/src/main/resources/spring/application-config.xml
@@ -16,5 +16,6 @@
         http://mybatis.org/schema/mybatis-spring.xsd">
 
     <mybatis:scan base-package="com.rakucari.aki.selectcategories.mapper"/>
+    <mybatis:scan base-package="com.rakucari.aki.selectgoodsoptions.mapper"/>
 
 </beans>


### PR DESCRIPTION
# 変更点
- 商品出品ページのセレクトボックスで表示する、カテゴリー、商品状態、配送料負担、発送元地域、発送予定日の有効な全リストを取得するAPIを実装。